### PR TITLE
enh: `Mean.get_value` now writes to slices, rather than `Vec`s

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ impl Mean {
         self.total[partition_idx] += val * weight;
     }
 
-    pub fn get_value(&self, out: &mut Vec<f64>, weights_out: &mut Vec<f64>) {
+    pub fn get_value(&self, out: &mut [f64], weights_out: &mut [f64]) {
         for i in 0..self.weight.len() {
             // TODO need to think about divide by 0
             out[i] = self.total[i] / self.weight[i];


### PR DESCRIPTION
This is a minor change to make `Mean.get_value` take the output buffers as mutable slices, `&mut [f64]`, rather than mutable vectors,  `&mut Vec<f64>`s.

This is more general (it lets people use a larger variety of types to hold the output buffers) and more idiomatic.