### PR TITLE
This was my first stab at introducing machinery for vectorization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 use ndarray::ArrayView2;
+mod vecpack;
+
+use vecpack::ScalarVecCompat;
 
 pub trait Accumulator {
     fn consume(&mut self, val: f64, weight: f64, bin_idx: usize);

--- a/src/vecpack.rs
+++ b/src/vecpack.rs
@@ -1,0 +1,257 @@
+//! This module is intended to introduce a placeholder type to help us
+//! "block-out" logic to properly support SIMD in the future
+//!
+//! At some point in the future, we should start playing with the std::simd or
+//! the glam crate
+//!
+//! The basic premise is that we create a struct, VecPack that mimics the role
+//! of a vector-register.
+//! - background: a vector-register holds `N` lanes of values. Many CPU
+//!   architectures support 2 f64 values or 4 f32 values (or integer types).
+//! - this struct acts like an array of `N` f64 values stored in
+//!   regular memory. We will implement a subset of operations binary
+//!   operations (e.g. addition, subtraction, multiplication) that operate on
+//!   pairs of VecPack instances.
+//! - if the struct has an alignment consistent with the corresponding vector
+//!   register (& we provide enough hints about the input data's alignment),
+//!   this can be really helpful for auto-vectorization
+//!   -> this is especially if you have lots of inlined operations within a
+//!      single function
+//!   -> autovectorization may not happen if you try to pass the struct
+//!      between (non-inlined functions). This has to do with the fact that
+//!      function calling conventions make certain assumptions about the
+//!      location of memory
+//!   -> we can help with vectorization by specializing certain operation to
+//!      use vector-intrinsics on a platform-by-platform basis.
+//! - this sort of technique is used in many languages. AFAICT, rust's
+//!   experimental std::simd feature also works this way. Thus, we should make
+//!   efforts to use the same interface as std::simd (so we can swap out)
+//!
+//! At the moment, vectorization is NOT presently the goal of these types.
+//! Instead, the goal is to "block-out" the requirements for achieving
+//! vectorization (and we can worry about vectorization later).
+
+use core::ops::{Add, AddAssign, Mul, Sub};
+use std::usize;
+
+// I don't love this
+pub trait ScalarVecCompat<Other = Self, Output = Self>:
+    Add<Other, Output = Output>
+    + AddAssign<Other>
+    + Sub<Other, Output = Output>
+    + Mul<Other, Output = Output>
+{
+    type T;
+    const NLANES: usize;
+    fn sqrt(self) -> Self;
+    fn copy_from(slice: &[Self::T], offset: usize) -> Self;
+    fn zero() -> Self;
+    fn shift_elements_left<const OFFSET: usize>(self, padding: Self::T) -> Self;
+}
+
+// make sure we don't let external code directly access the underlying array
+// (in the future, we may consider enforcing alignment)
+#[derive(Copy, Clone)]
+struct VecPack<T, const N: usize>([T; N]);
+
+// for Add, Sub, and Mul we may want to use a procedural macro
+impl<T: Add<Output = T> + Copy, const N: usize> Add for VecPack<T, N> {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        let mut tmp = self.0;
+        for i in 0..N {
+            tmp[i] = self.0[i] + other.0[i];
+        }
+        Self(tmp)
+    }
+}
+
+impl<T: AddAssign + Copy, const N: usize> AddAssign for VecPack<T, N> {
+    fn add_assign(&mut self, rhs: Self) {
+        for i in 0..N {
+            self.0[i] += rhs.0[i];
+        }
+    }
+}
+
+impl<T: Sub<Output = T> + Copy, const N: usize> Sub for VecPack<T, N> {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        let mut tmp = self.0;
+        for i in 0..N {
+            tmp[i] = self.0[i] - other.0[i];
+        }
+        Self(tmp)
+    }
+}
+
+impl<T: Mul<Output = T> + Copy, const N: usize> Mul for VecPack<T, N> {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        let mut tmp = self.0;
+        for i in 0..N {
+            tmp[i] = self.0[i] * other.0[i];
+        }
+        Self(tmp)
+    }
+}
+
+impl<T: Copy, const N: usize> VecPack<T, N> {
+    const LEN: usize = N;
+
+    pub const fn len(&self) -> usize {
+        return N;
+    }
+
+    #[inline]
+    pub fn from_array(array: [T; N]) -> Self {
+        Self(array.clone())
+    }
+
+    #[inline]
+    pub fn from_slice(slice: &[T]) -> Self {
+        assert!(slice.len() >= Self::LEN);
+        Self(<[T; N]>::try_from(slice).unwrap())
+    }
+
+    pub fn to_array(&self) -> [T; N] {
+        self.0
+    }
+
+    /// initializes all elements to a single value
+    pub fn splat(value: T) -> Self {
+        Self([value; N])
+    }
+}
+
+impl<const N: usize> VecPack<f32, N> {
+    // this currently requires that we use std
+    pub fn sqrt(self) -> Self {
+        let mut out = self;
+        for i in 0..N {
+            out.0[i] = self.0[i].sqrt();
+        }
+        out
+    }
+}
+
+impl<const N: usize> VecPack<f64, N> {
+    // this currently requires that we use std
+    pub fn sqrt(self) -> Self {
+        let mut out = self;
+        for i in 0..N {
+            out.0[i] = self.0[i].sqrt();
+        }
+        out
+    }
+}
+
+/*
+fn has_alignment(slc: &[f64], align: usize) -> bool {
+    // there are special rules about manually tracking pointer lifetimes
+    // (I think we will be okay since the slice definitely outlives the ptr)
+    let ptr = slc.as_ptr();
+    ptr.addr() % align == 0
+}
+*/
+
+impl ScalarVecCompat for f64 {
+    type T = Self;
+    const NLANES: usize = 1;
+
+    fn sqrt(self) -> Self {
+        self.sqrt()
+    }
+
+    fn copy_from(slice: &[f64], offset: usize) -> Self {
+        slice[offset]
+    }
+
+    fn zero() -> Self {
+        0.0
+    }
+    fn shift_elements_left<const OFFSET: usize>(self, padding: f64) -> f64 {
+        if OFFSET > 0 {
+            self
+        } else {
+            padding
+        }
+    }
+}
+
+impl<const N: usize> ScalarVecCompat for VecPack<f64, N> {
+    type T = f64;
+    const NLANES: usize = N;
+
+    fn sqrt(self) -> Self {
+        self.sqrt()
+    }
+
+    fn copy_from(slice: &[f64], offset: usize) -> Self {
+        Self::from_slice(&slice[offset..])
+    }
+
+    fn zero() -> Self {
+        Self::splat(0.0)
+    }
+
+    // should be exactly like std::simd shift_elements_left
+    fn shift_elements_left<const OFFSET: usize>(self, padding: f64) -> Self {
+        if OFFSET >= N {
+            Self::splat(padding)
+        } else {
+            let mut out = self;
+            let n_copied = N - OFFSET;
+            out.0[..n_copied].clone_from_slice(&self.0[OFFSET..]);
+            out.0[n_copied..].fill(padding);
+            out
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add() {
+        let v0 = VecPack::from_array([0., 1., 2., 3.]);
+        let v1 = VecPack::from_array([4., 5., 6., 7.]);
+        let sum = v0 + v1;
+        assert_eq!(sum.to_array(), [4., 6., 8., 10.]);
+    }
+
+    #[test]
+    fn sub() {
+        let v0 = VecPack::from_array([0., 1., 2., 3.]);
+        let v1 = VecPack::from_array([4., 5., 6., 7.]);
+        let diff = v1 - v0;
+        assert_eq!(diff.to_array(), [4., 4., 4., 4.]);
+    }
+
+    #[test]
+    fn mul() {
+        let v0 = VecPack::from_array([0., 1., 2., 3.]);
+        let v1 = VecPack::from_array([4., 5., 6., 7.]);
+        let product = v0 * v1;
+        assert_eq!(product.to_array(), [0., 5., 12., 21.]);
+    }
+
+    const fn _get_nlanes<T: ScalarVecCompat>(_: &T) -> usize {
+        T::NLANES
+    }
+
+    #[test]
+    fn misc() {
+        let v0 = VecPack::from_array([0., 1., 2., 3.]);
+        assert_eq!(_get_nlanes(&v0), 4);
+    }
+
+    #[test]
+    fn dummy() {
+        let val = 4.0;
+        assert_eq!(<f64 as ScalarVecCompat>::sqrt(val), 2.);
+    }
+}


### PR DESCRIPTION
The logic in this PR is a bit of a mess and a little half-backed. If you don't want to merge this in until things are more ready, we can work off of this PR for a while

------

This lays the foundation for machinery for supporting vectorization.

This PR introduces machinery for helping us to "block out" algorithmic decisions that will be used to achieve vectorization (I don't think that actually using this machinery directly will necessarily achieve it... I think we need to work on vector-alignment).

## `VecPack<T, const N: u_size>`

We introduce a `VecPack<T,N>` type (`T` is `f32` or `f64`, while `N` is the number of lanes) to mirror the role of a vector register. I left comments at the top of `vecpack.rs` to provide more context.
- This plays a similar role to `std::simd` (a nightly compiler feature) and [glam](https://docs.rs/glam/latest/glam/) (the go-to crate for this sort of things)[^1].
- Those other modules have some "special sauce" that make them immediately work better with vectorization (depending on how things are compiled, some methods are directly implemented using vector intrinsics).
- If we wanted to maximize performance with a custom solution like this, we might want to move away from using generics. In an ideal world, we want to overalign the structs, but I have concluded this isn't possible with the generic approach for stable-rust types with generics. `std::simd` appears to work around this  by adding a new nightly feature to the rust-compiler (`[repr(simd)]`), while `glam` appears to work around this by avoiding generics entirely (each vector type in glam is a concrete type).
- Be aware, some of the operations may be implemented in a suboptimal manner.

I think we *probably* want to use `glam` instead of our custom `VecPack<T, const N: u_size>`, since `glam` seems like the de facto choice.
- the primary reason we aren't using it is that I didn't know about it until I made it pretty far with this PR.
- for a while, I also thought we might want to be able to make the number of lanes a template parameter, and I was concerned that `glam` uses concrete types (for context, `VecPack<f64,2>` & `glam::DVec2` are counterparts while `VecPack<f64,4>` and `glam::DVec4` are counterparts). But, I think I've concluded that we probably isn't much advantage to allowing the number of lanes be a generic if we also want to support the use of scalars, (which we probably want to do for GPU-support).


I do have a couple concerns about getting the most out of `f64x4` vectors (we would currently call this `VecPack<f64, 4>` and `glam` calls this `glam::DVec`). I'll go into detail below (if only for the sake of posterity):
- `glam` only directly implements operations with SIMD intrinsics for vectors that take up to 128-bits of memory (e.g. `f32x4` or `f64x2`).
   - to ensure vectorization of these operations on x86, `glam` would need to implement `glam::DVec` using AVX (or AVX2) intrinsics. But `glam` only supports `SSE` and `SSE2` instructions.[^2]
   - the `glam` developer probably made these choices for the sake of portability... The max SIMD Vector size on ARM CPUs and PowerPC CPUs is 128 bits
   - With that said, `glam` supports using `std::simd` as a backend (instead of SIMD intrinsics). So this could all come out in the wash.
- `glam` has a limitation where it doesn't directly support `std::simd`'s [shift_element_left](https://doc.rust-lang.org/std/simd/struct.Simd.html#method.shift_elements_left) method (we need this operation in a particular context)[^3] 
- the above point suggests that we may want to consider supporting `f32` for more portable performance
   - I worry a little about precision limitations since we run accumulators over lots of points. We may need to consider something like Kahn Summation (or a higher-order alternative) to work around this
- One other thought: if we *really* want AVX instructions, we could add our own custom type
- With all of this said, we may just want to rely upon auto-vectorization and not spend too much time worrying about this (`glam` has a backend well-suited to this).
- **Instead of focusing on vectorization**, I think we may want to focus more on GPU support and I'm pretty sure `glam` is extremely well supported by the relevant GPU frameworks

## The `ScalarVecCompat` trait

The basic idea here is to support a function generic over `f64` & `VecPack<f64, 4>` (and maybe `VecPack<f64, 2>`). This seems a little clunky, but I've generally concluded that this is "the right thing to do". If we start using `glam`, we'll obviously need to implement this trait for `glam::DVec4`.

In principle, we could use a slightly modified version of the `Float` trait from the popular  [`num`](crates.io/crates/num) crate, but I decided against it  for a few reasons:
1. `num::Float` covers a lot of functionality (we probably don't care about most of it)
2. `num::Float` requires the crate to be compiled with `std`. We probably want `no-std` support (to make it easier to support GPUs).
3. we would need to extend `num::Float` in order to add the basic vectorization operations

I'm open to other considerations

[^1]: `glam` is primarily designed (and tailored) for use with video game graphics logic. The way our memory is organized doesn't perfectly do this. With that said, the core mathematical operations we need are **VERY** simple.

[^2]: For more context about simd instruction sets on x86: 
      - `SSE`, `SSE2`. `SSE3`, `SSSE3` and `SSE4` (not a typo) add instructions for 128bit vector-registers
      - `AVX` and `AVX2` provide instructions for 256bit vector
      - `AVX512` (I think there may be a bunch of flavors) provide instructions for 512bit vectors. My impression is that these instructions are famously hard to leverage (I remember reading stories that they could slow down code if the code isn't tailored to these instructions). Plus, they aren't widely available on consumer CPUs.
 
[^3]: I think we may be able to work around this with `swizzle` operations. But there is probably a latency consideration.