### PR TITLE
Bins types

### DIFF
--- a/crates/pairwise/src/lib.rs
+++ b/crates/pairwise/src/lib.rs
@@ -6,7 +6,8 @@ mod reducers;
 // pull in symbols that visible outside of the package
 pub use misc::diff_norm;
 pub use pairwise_nostd_internal::{
-    Executor, Mean, OutputDescr, PointProps, Reducer, StatePackViewMut, apply_accum, dot_product,
+    Executor, Histogram, Mean, OutputDescr, PointProps, Reducer, StatePackViewMut, apply_accum,
+    dot_product,
 };
 pub use parallel_serial::SerialExecutor;
-pub use reducers::{Histogram, get_output, get_output_from_statepack_array};
+pub use reducers::{get_output, get_output_from_statepack_array};

--- a/crates/pairwise/src/reducers.rs
+++ b/crates/pairwise/src/reducers.rs
@@ -1,10 +1,8 @@
 use std::collections::HashMap;
 
-use ndarray::{ArrayView1, ArrayView2, ArrayViewMut1, ArrayViewMut2, Axis};
+use ndarray::{ArrayView1, ArrayView2, ArrayViewMut2, Axis};
 
-use pairwise_nostd_internal::{
-    AccumStateView, AccumStateViewMut, Datum, OutputDescr, Reducer, StatePackViewMut,
-};
+use pairwise_nostd_internal::{AccumStateView, OutputDescr, Reducer, StatePackViewMut};
 
 /// compute the output quantities from an accumulator's state properties and
 /// return the result in a HashMap.

--- a/crates/pairwise/src/reducers.rs
+++ b/crates/pairwise/src/reducers.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use ndarray::{ArrayView1, ArrayView2, ArrayViewMut1, ArrayViewMut2, Axis};
 
 use pairwise_nostd_internal::{
-    AccumStateView, AccumStateViewMut, Datum, OutputDescr, Reducer, StatePackViewMut, get_bin_idx,
+    AccumStateView, AccumStateViewMut, Datum, OutputDescr, Reducer, StatePackViewMut,
 };
 
 /// compute the output quantities from an accumulator's state properties and
@@ -75,68 +75,5 @@ pub fn get_output_from_statepack_array(
             HashMap::from_iter(names.iter().cloned().zip(row_iter))
         }
         OutputDescr::SingleVecComp { name, .. } => HashMap::from([(name, buffer)]),
-    }
-}
-
-// TODO: refactor so that Histogram doesn't hold a vector and move to
-//       pairwise_internal/accumulator.rs (to )
-pub struct Histogram {
-    // maybe call these hist_bucket_edges?
-    hist_bin_edges: Vec<f64>,
-    n_hist_bins: usize,
-}
-
-impl Histogram {
-    pub fn new(hist_bin_edges: &[f64]) -> Result<Histogram, &'static str> {
-        if hist_bin_edges.len() < 2 {
-            Err("hist_bin_edges must include at least 2 elements")
-        } else if !hist_bin_edges.is_sorted() {
-            Err("hist_bin_edges must be monotonically increasing")
-        } else {
-            let n_hist_bins = hist_bin_edges.len() - 1;
-            Ok(Histogram {
-                hist_bin_edges: hist_bin_edges.to_vec(),
-                n_hist_bins,
-            })
-        }
-    }
-}
-
-impl Reducer for Histogram {
-    fn accum_state_size(&self) -> usize {
-        self.n_hist_bins
-    }
-
-    /// initializes the storage tracking the acumulator's state
-    fn init_accum_state(&self, accum_state: &mut AccumStateViewMut) {
-        accum_state.fill(0.0);
-    }
-
-    /// consume the value and weight to update the accum_state
-    fn consume(&self, accum_state: &mut AccumStateViewMut, datum: &Datum) {
-        if let Some(hist_bin_idx) = get_bin_idx(datum.value, &self.hist_bin_edges) {
-            accum_state[hist_bin_idx] += datum.weight;
-        }
-    }
-
-    /// merge the state information tracked by `accum_state` and `other`, and
-    /// update `accum_state` accordingly
-    fn merge(&self, accum_state: &mut AccumStateViewMut, other: &AccumStateView) {
-        for i in 0..self.n_hist_bins {
-            accum_state[i] += other[i];
-        }
-    }
-
-    fn output_descr(&self) -> OutputDescr {
-        OutputDescr::SingleVecComp {
-            size: self.n_hist_bins,
-            name: "weight",
-        }
-    }
-
-    fn value_from_accum_state(&self, value: &mut ArrayViewMut1<f64>, accum_state: &AccumStateView) {
-        for i in 0..self.n_hist_bins {
-            value[[i]] = accum_state[i];
-        }
     }
 }

--- a/crates/pairwise/tests/accumulator_tests.rs
+++ b/crates/pairwise/tests/accumulator_tests.rs
@@ -21,6 +21,7 @@ fn _get_output_single(
 mod tests {
 
     use super::*;
+    use pairwise_nostd_internal::{IrregularBins, RegularBins};
 
     #[test]
     fn mean_consume_once() {
@@ -119,17 +120,8 @@ mod tests {
     }
 
     #[test]
-    fn hist_invalid_hist_edges() {
-        assert!(Histogram::new(&[0.0]).is_err());
-    }
-    #[test]
-    fn hist_nonmonotonic() {
-        assert!(Histogram::new(&[1.0, 0.0]).is_err());
-    }
-
-    #[test]
     fn hist_consume() {
-        let reducer = Histogram::new(&[0.0, 1.0, 2.0]).unwrap();
+        let reducer = Histogram::from_bins(RegularBins::new(0.0, 2.0, 2).unwrap());
 
         let mut storage = [0.0, 0.0];
         let mut accum_state = AccumStateViewMut::from_contiguous_slice(&mut storage);

--- a/crates/pairwise/tests/accumulator_tests.rs
+++ b/crates/pairwise/tests/accumulator_tests.rs
@@ -21,7 +21,7 @@ fn _get_output_single(
 mod tests {
 
     use super::*;
-    use pairwise_nostd_internal::RegularBins;
+    use pairwise_nostd_internal::RegularBinEdges;
 
     #[test]
     fn mean_consume_once() {
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn hist_consume() {
-        let reducer = Histogram::from_bins(RegularBins::new(0.0, 2.0, 2).unwrap());
+        let reducer = Histogram::from_bin_edges(RegularBinEdges::new(0.0, 2.0, 2).unwrap());
 
         let mut storage = [0.0, 0.0];
         let mut accum_state = AccumStateViewMut::from_contiguous_slice(&mut storage);

--- a/crates/pairwise/tests/accumulator_tests.rs
+++ b/crates/pairwise/tests/accumulator_tests.rs
@@ -21,7 +21,7 @@ fn _get_output_single(
 mod tests {
 
     use super::*;
-    use pairwise_nostd_internal::{IrregularBins, RegularBins};
+    use pairwise_nostd_internal::RegularBins;
 
     #[test]
     fn mean_consume_once() {

--- a/crates/pairwise/tests/common/mod.rs
+++ b/crates/pairwise/tests/common/mod.rs
@@ -95,11 +95,11 @@ pub fn assert_consistent_results(
 
 // helper function that sets up the statepack, which holds one accum_state
 // per spatial bin
-pub fn prepare_statepack(n_spatial_bins: usize, reducer: &impl Reducer) -> Array2<f64> {
-    assert!(n_spatial_bins > 0);
-    let mut statepack = Array2::<f64>::zeros((reducer.accum_state_size(), n_spatial_bins));
+pub fn prepare_statepack(n_bins: usize, reducer: &impl Reducer) -> Array2<f64> {
+    assert!(n_bins > 0);
+    let mut statepack = Array2::<f64>::zeros((reducer.accum_state_size(), n_bins));
     let mut statepack_view = StatePackViewMut::from_array_view(statepack.view_mut());
-    for i in 0..n_spatial_bins {
+    for i in 0..n_bins {
         reducer.init_accum_state(&mut statepack_view.get_state_mut(i));
     }
     statepack

--- a/crates/pairwise/tests/integration_tests.rs
+++ b/crates/pairwise/tests/integration_tests.rs
@@ -11,6 +11,8 @@ use pairwise::{
 
 #[cfg(test)]
 mod tests {
+    use pairwise_nostd_internal::IrregularBins;
+
     use super::*;
 
     // based on numpy!
@@ -182,18 +184,18 @@ mod tests {
 
         // check the histograms (using results computed by pyvsf)
 
-        // the hist_bin_edges were picked such that:
+        // the hist_buckets were picked such that:
         // - the number of bins is unequal to the distance bin count
         // - there would be a value smaller than the leftmost bin-edge
         // - there would be a value larger than the leftmost bin-edge
-        let hist_bin_edges = [6.0, 10.0, 14.0];
+        let hist_buckets = IrregularBins::new(&[6.0, 10.0, 14.0]).unwrap();
 
         #[rustfmt::skip]
         let expected_hist_weights = [
             4., 0., 0.,
             3., 2., 0.,
         ];
-        let hist_reducer = Histogram::new(&hist_bin_edges).unwrap();
+        let hist_reducer = Histogram::from_bins(hist_buckets);
         let mut hist_statepack = prepare_statepack(distance_bin_edges.len() - 1, &hist_reducer);
         let result = apply_accum(
             &mut StatePackViewMut::from_array_view(hist_statepack.view_mut()),

--- a/crates/pairwise/tests/integration_tests.rs
+++ b/crates/pairwise/tests/integration_tests.rs
@@ -11,7 +11,7 @@ use pairwise::{
 
 #[cfg(test)]
 mod tests {
-    use pairwise_nostd_internal::IrregularBins;
+    use pairwise_nostd_internal::IrregularBinEdges;
 
     use super::*;
 
@@ -48,7 +48,7 @@ mod tests {
         ];
 
         let squared_distance_bin_edges = [0.0, 1.0, 9.0, 16.0];
-        let squared_distance_bins = IrregularBins::new(&squared_distance_bin_edges).unwrap();
+        let squared_distance_bins = IrregularBinEdges::new(&squared_distance_bin_edges).unwrap();
         let reducer = Mean;
         let mut statepack = prepare_statepack(squared_distance_bin_edges.len(), &reducer);
         let points = PointProps::new(
@@ -109,7 +109,7 @@ mod tests {
         // inside the bottom bin
         let distance_bin_edges: [f64; 4] = [2.0, 6., 10., 15.];
         let squared_bin_edges = distance_bin_edges.map(|x| x.powi(2));
-        let squared_distance_bins = IrregularBins::new(&squared_bin_edges).unwrap();
+        let squared_distance_bins = IrregularBinEdges::new(&squared_bin_edges).unwrap();
 
         // check the means (using results computed by pyvsf)
         let expected_mean = [8.41281820819169, 15.01110699893027, f64::NAN];
@@ -157,14 +157,14 @@ mod tests {
         // - the number of bins is unequal to the distance bin count
         // - there would be a value smaller than the leftmost bin-edge
         // - there would be a value larger than the leftmost bin-edge
-        let hist_buckets = IrregularBins::new(&[6.0, 10.0, 14.0]).unwrap();
+        let hist_buckets = IrregularBinEdges::new(&[6.0, 10.0, 14.0]).unwrap();
 
         #[rustfmt::skip]
         let expected_hist_weights = [
             4., 0., 0.,
             3., 2., 0.,
         ];
-        let hist_reducer = Histogram::from_bins(hist_buckets);
+        let hist_reducer = Histogram::from_bin_edges(hist_buckets);
         let mut hist_statepack = prepare_statepack(distance_bin_edges.len() - 1, &hist_reducer);
         let result = apply_accum(
             &mut StatePackViewMut::from_array_view(hist_statepack.view_mut()),
@@ -228,7 +228,7 @@ mod tests {
 
         let distance_bin_edges: [f64; 3] = [17., 21., 25.];
         let squared_bin_edges = distance_bin_edges.map(|x| x.powi(2));
-        let square_distance_bins = IrregularBins::new(&squared_bin_edges).unwrap();
+        let square_distance_bins = IrregularBinEdges::new(&squared_bin_edges).unwrap();
 
         // the expected results were printed by pyvsf
         let expected_mean = [6.274664681905207, 6.068727871100932];
@@ -273,7 +273,7 @@ mod tests {
         // inside the bottom bin
         let distance_bin_edges: [f64; 4] = [2., 6., 10., 15.];
         let squared_bin_edges = distance_bin_edges.map(|x| x.powi(2));
-        let squared_distance_bins = IrregularBins::new(&squared_bin_edges).unwrap();
+        let squared_distance_bins = IrregularBinEdges::new(&squared_bin_edges).unwrap();
 
         // check the means (using results computed by pyvsf)
         let expected_mean = [284.57142857142856, 236.0, f64::NAN];

--- a/crates/pairwise_nostd_internal/src/apply_points.rs
+++ b/crates/pairwise_nostd_internal/src/apply_points.rs
@@ -1,4 +1,5 @@
-use crate::misc::{get_bin_idx, squared_diff_norm};
+use crate::bins::Bins;
+use crate::misc::squared_diff_norm;
 use crate::reducer::{Datum, Reducer};
 use crate::state::StatePackViewMut;
 use ndarray::ArrayView2;
@@ -66,37 +67,6 @@ impl<'a> PointProps<'a> {
     }
 }
 
-fn apply_accum_helper<const CROSS: bool>(
-    statepack: &mut StatePackViewMut,
-    reducer: &impl Reducer,
-    points_a: &PointProps,
-    points_b: &PointProps,
-    squared_bin_edges: &[f64],
-    pairwise_fn: impl Fn(ArrayView2<f64>, ArrayView2<f64>, usize, usize) -> f64,
-) {
-    for i_a in 0..points_a.n_points {
-        let i_b_start = if CROSS { i_a + 1 } else { 0 };
-        for i_b in i_b_start..points_b.n_points {
-            // compute the distance between the points, then the distance bin
-            let distance_squared = squared_diff_norm(
-                points_a.positions,
-                points_b.positions,
-                i_a,
-                i_b,
-                points_a.n_spatial_dims,
-            );
-            if let Some(distance_bin_idx) = get_bin_idx(distance_squared, squared_bin_edges) {
-                let datum = Datum {
-                    value: pairwise_fn(points_a.values, points_b.values, i_a, i_b),
-                    weight: points_a.get_weight(i_a) * points_b.get_weight(i_b),
-                };
-
-                reducer.consume(&mut statepack.get_state_mut(distance_bin_idx), &datum);
-            }
-        }
-    }
-}
-
 /// Computes contributions to binned statistics from values computed from the
 /// specified pairs of points.
 ///
@@ -125,16 +95,11 @@ pub fn apply_accum(
     reducer: &impl Reducer,
     points_a: &PointProps,
     points_b: Option<&PointProps>,
-    squared_distance_bin_edges: &[f64],
+    squared_distance_bins: &impl Bins,
     pairwise_fn: &impl Fn(ArrayView2<f64>, ArrayView2<f64>, usize, usize) -> f64,
 ) -> Result<(), &'static str> {
     // maybe we make separate functions for auto-stats vs cross-stats?
     // TODO: check size of output buffers
-
-    // Check that bin_edges are monotonically increasing
-    if !squared_distance_bin_edges.is_sorted() {
-        return Err("squared_distance_bin_edges must monotonically increase");
-    }
 
     //  if points_b is not None, make sure a and b have the same number of
     // spatial dimensions
@@ -155,7 +120,7 @@ pub fn apply_accum(
             reducer,
             points_a,
             points_b,
-            squared_distance_bin_edges,
+            squared_distance_bins,
             pairwise_fn,
         )
     } else {
@@ -164,9 +129,40 @@ pub fn apply_accum(
             reducer,
             points_a,
             points_a,
-            squared_distance_bin_edges,
+            squared_distance_bins,
             pairwise_fn,
         )
     }
     Ok(())
+}
+
+fn apply_accum_helper<const CROSS: bool>(
+    statepack: &mut StatePackViewMut,
+    reducer: &impl Reducer,
+    points_a: &PointProps,
+    points_b: &PointProps,
+    squared_distance_bins: &impl Bins,
+    pairwise_fn: impl Fn(ArrayView2<f64>, ArrayView2<f64>, usize, usize) -> f64,
+) {
+    for i_a in 0..points_a.n_points {
+        let i_b_start = if CROSS { i_a + 1 } else { 0 };
+        for i_b in i_b_start..points_b.n_points {
+            // compute the distance between the points, then the distance bin
+            let distance_squared = squared_diff_norm(
+                points_a.positions,
+                points_b.positions,
+                i_a,
+                i_b,
+                points_a.n_spatial_dims,
+            );
+            if let Some(distance_bin_idx) = squared_distance_bins.bin_index(distance_squared) {
+                let datum = Datum {
+                    value: pairwise_fn(points_a.values, points_b.values, i_a, i_b),
+                    weight: points_a.get_weight(i_a) * points_b.get_weight(i_b),
+                };
+
+                reducer.consume(&mut statepack.get_state_mut(distance_bin_idx), &datum);
+            }
+        }
+    }
 }

--- a/crates/pairwise_nostd_internal/src/apply_points.rs
+++ b/crates/pairwise_nostd_internal/src/apply_points.rs
@@ -1,4 +1,4 @@
-use crate::bins::Bins;
+use crate::bins::BinEdges;
 use crate::misc::squared_diff_norm;
 use crate::reducer::{Datum, Reducer};
 use crate::state::StatePackViewMut;
@@ -95,7 +95,7 @@ pub fn apply_accum(
     reducer: &impl Reducer,
     points_a: &PointProps,
     points_b: Option<&PointProps>,
-    squared_distance_bins: &impl Bins,
+    squared_distance_bin_edges: &impl BinEdges,
     pairwise_fn: &impl Fn(ArrayView2<f64>, ArrayView2<f64>, usize, usize) -> f64,
 ) -> Result<(), &'static str> {
     // maybe we make separate functions for auto-stats vs cross-stats?
@@ -120,7 +120,7 @@ pub fn apply_accum(
             reducer,
             points_a,
             points_b,
-            squared_distance_bins,
+            squared_distance_bin_edges,
             pairwise_fn,
         )
     } else {
@@ -129,7 +129,7 @@ pub fn apply_accum(
             reducer,
             points_a,
             points_a,
-            squared_distance_bins,
+            squared_distance_bin_edges,
             pairwise_fn,
         )
     }
@@ -141,7 +141,7 @@ fn apply_accum_helper<const CROSS: bool>(
     reducer: &impl Reducer,
     points_a: &PointProps,
     points_b: &PointProps,
-    squared_distance_bins: &impl Bins,
+    squared_distance_bin_edges: &impl BinEdges,
     pairwise_fn: impl Fn(ArrayView2<f64>, ArrayView2<f64>, usize, usize) -> f64,
 ) {
     for i_a in 0..points_a.n_points {
@@ -155,7 +155,7 @@ fn apply_accum_helper<const CROSS: bool>(
                 i_b,
                 points_a.n_spatial_dims,
             );
-            if let Some(distance_bin_idx) = squared_distance_bins.bin_index(distance_squared) {
+            if let Some(distance_bin_idx) = squared_distance_bin_edges.bin_index(distance_squared) {
                 let datum = Datum {
                     value: pairwise_fn(points_a.values, points_b.values, i_a, i_b),
                     weight: points_a.get_weight(i_a) * points_b.get_weight(i_b),

--- a/crates/pairwise_nostd_internal/src/bins.rs
+++ b/crates/pairwise_nostd_internal/src/bins.rs
@@ -5,13 +5,14 @@
 /// Super simple. This can be expanded as needed.
 pub trait BinEdges {
     /// Calculate the bin index for a given value. Values which are equal to
-    /// boundary values are considered part of the higher bin.
+    /// boundary values are considered part of the higher bin, i.e. intervals
+    /// do not include the right edge.
     fn bin_index(&self, value: f64) -> Option<usize>;
 
-    fn len(&self) -> usize;
+    fn n_bins(&self) -> usize;
 
     fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.n_bins() == 0
     }
 }
 
@@ -55,7 +56,7 @@ impl BinEdges for RegularBinEdges {
         Some(index)
     }
 
-    fn len(&self) -> usize {
+    fn n_bins(&self) -> usize {
         self.n_bins
     }
 }
@@ -104,7 +105,7 @@ impl BinEdges for IrregularBinEdges<'_> {
         Some(index)
     }
 
-    fn len(&self) -> usize {
+    fn n_bins(&self) -> usize {
         self.bin_edges.len() - 1
     }
 }
@@ -149,7 +150,7 @@ mod tests {
         let bins_list: [&dyn BinEdges; 2] = [&rbins, &ibins];
 
         for bins in &bins_list {
-            assert_eq!(bins.len(), 5);
+            assert_eq!(bins.n_bins(), 5);
 
             // Test valid values
             assert_eq!(bins.bin_index(0.0), Some(0));
@@ -171,7 +172,7 @@ mod tests {
     fn irregular_bins_bin_indexing() {
         let bins = IrregularBinEdges::new(&[-5.0, 0.0, 2.0, 3.0]).unwrap();
 
-        assert_eq!(bins.len(), 3);
+        assert_eq!(bins.n_bins(), 3);
 
         // Test valid values
         assert_eq!(bins.bin_index(-5.0), Some(0));

--- a/crates/pairwise_nostd_internal/src/bins.rs
+++ b/crates/pairwise_nostd_internal/src/bins.rs
@@ -1,6 +1,6 @@
 //! Implements types to represent "bins", used for Histogram buckets and for
 //! distance binning of accumulators.  The Bins trait provides a common
-//! interface which is implemented by RegularBins and IrrigularBins. These
+//! interface which is implemented by RegularBins and IrregularBins. These
 //! types do NOT "hold" data, they only define the bin edges and determine the
 //! bin index for a given value.
 

--- a/crates/pairwise_nostd_internal/src/bins.rs
+++ b/crates/pairwise_nostd_internal/src/bins.rs
@@ -10,10 +10,6 @@ pub trait BinEdges {
     fn bin_index(&self, value: f64) -> Option<usize>;
 
     fn n_bins(&self) -> usize;
-
-    fn is_empty(&self) -> bool {
-        self.n_bins() == 0
-    }
 }
 
 /// Regular bins with uniform spacing

--- a/crates/pairwise_nostd_internal/src/bins.rs
+++ b/crates/pairwise_nostd_internal/src/bins.rs
@@ -1,0 +1,87 @@
+//! Implements types to represent "bins", used for Histogram buckets and for
+//!  distance binning of accumulators.  The Bins trait provides a common
+//! interface which is implemented by RegularBins and IrrigularBins. These
+//! types do NOT "hold" data, they only define the bin edges and determine the
+//! bin index for a given value.
+
+/// Super simple. This can be expanded as needed.
+pub trait Bins {
+    /// Calculate the bin index for a given value. Values which are equal to
+    /// boundary values are considered part of the higher bin.
+    fn bin_index(&self, value: f64) -> Option<usize>;
+}
+
+/// Regular bins with uniform spacing
+#[derive(Clone)]
+pub struct RegularBins {
+    min: f64,
+    max: f64,
+    bin_size: f64,
+}
+impl RegularBins {
+    /// Note that we initialize with num_bins rather than bin_size
+    pub fn new(min: f64, max: f64, num_bins: usize) -> Result<Self, &'static str> {
+        if num_bins == 0 {
+            Err("Number of bins must be greater than zero")
+        } else if max <= min {
+            Err("Maximum value must be greater than minimum value")
+        } else if !min.is_finite() || !max.is_finite() {
+            Err("Min and max values must be finite")
+        } else {
+            Ok(Self {
+                min,
+                max,
+                bin_size: (max - min) / num_bins as f64,
+            })
+        }
+    }
+}
+
+impl Bins for RegularBins {
+    fn bin_index(&self, value: f64) -> Option<usize> {
+        if value < self.min || value >= self.max {
+            return None;
+        }
+
+        let index = ((value - self.min) / self.bin_size).floor() as usize;
+        Some(index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_regular_bins_invalid_creation() {
+        // Zero bins
+        assert!(RegularBins::new(0.0, 10.0, 0).is_err());
+
+        // Max <= min
+        assert!(RegularBins::new(10.0, 10.0, 5).is_err());
+        assert!(RegularBins::new(10.0, 5.0, 5).is_err());
+
+        // Non-finite values
+        assert!(RegularBins::new(f64::NAN, 10.0, 5).is_err());
+        assert!(RegularBins::new(0.0, f64::INFINITY, 5).is_err());
+    }
+
+    #[test]
+    fn test_regular_bins_bin_index() {
+        let bins = RegularBins::new(0.0, 10.0, 5).unwrap();
+
+        // Test valid values
+        assert_eq!(bins.bin_index(0.0), Some(0));
+        assert_eq!(bins.bin_index(1.9), Some(0));
+        assert_eq!(bins.bin_index(2.0), Some(1));
+        assert_eq!(bins.bin_index(3.9), Some(1));
+        assert_eq!(bins.bin_index(4.0), Some(2));
+        assert_eq!(bins.bin_index(8.0), Some(4));
+        assert_eq!(bins.bin_index(9.9), Some(4));
+
+        // Test boundary conditions
+        assert_eq!(bins.bin_index(10.0), None); // max is exclusive
+        assert_eq!(bins.bin_index(-0.1), None); // below min
+        assert_eq!(bins.bin_index(10.1), None); // above max
+    }
+}

--- a/crates/pairwise_nostd_internal/src/bins.rs
+++ b/crates/pairwise_nostd_internal/src/bins.rs
@@ -51,7 +51,9 @@ impl BinEdges for RegularBinEdges {
             return None;
         }
 
-        let index = ((value - self.min) / self.bin_size).floor() as usize;
+        // this cast handles the truncation
+        let index = ((value - self.min) / self.bin_size) as usize;
+
         Some(index)
     }
 

--- a/crates/pairwise_nostd_internal/src/bins.rs
+++ b/crates/pairwise_nostd_internal/src/bins.rs
@@ -1,8 +1,6 @@
-//! Implements types to represent "bins", used for Histogram buckets and for
-//! distance binning of accumulators.  The Bins trait provides a common
-//! interface which is implemented by RegularBins and IrregularBins. These
-//! types do NOT "hold" data, they only define the bin edges and determine the
-//! bin index for a given value.
+//! Implements types to represent "bin edges", used for Histogram buckets and for
+//! distance binning of accumulators.  The [`BinEdges`] trait provides a common
+//! interface that is implemented by [`RegularBinEdges`] and [`IrregularBinEdges`]
 
 /// Super simple. This can be expanded as needed.
 pub trait BinEdges {

--- a/crates/pairwise_nostd_internal/src/bins.rs
+++ b/crates/pairwise_nostd_internal/src/bins.rs
@@ -134,6 +134,7 @@ mod tests {
 
         // unsorted bin edges
         assert!(IrregularBins::new(&[2.0, 1.0]).is_err());
+        assert!(IrregularBins::new(&[0.0, 3.0, 2.0]).is_err());
 
         // Non-finite values
         assert!(IrregularBins::new(&[f64::NAN, 10.0]).is_err());

--- a/crates/pairwise_nostd_internal/src/bins.rs
+++ b/crates/pairwise_nostd_internal/src/bins.rs
@@ -1,5 +1,5 @@
 //! Implements types to represent "bins", used for Histogram buckets and for
-//!  distance binning of accumulators.  The Bins trait provides a common
+//! distance binning of accumulators.  The Bins trait provides a common
 //! interface which is implemented by RegularBins and IrrigularBins. These
 //! types do NOT "hold" data, they only define the bin edges and determine the
 //! bin index for a given value.

--- a/crates/pairwise_nostd_internal/src/lib.rs
+++ b/crates/pairwise_nostd_internal/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 mod apply_points;
+mod bins;
 mod misc;
 mod parallel;
 mod reduce_utils;

--- a/crates/pairwise_nostd_internal/src/lib.rs
+++ b/crates/pairwise_nostd_internal/src/lib.rs
@@ -13,7 +13,7 @@ pub mod reduce_sample;
 
 pub use apply_points::{PointProps, apply_accum};
 pub use bins::*;
-pub use misc::{dot_product, get_bin_idx, squared_diff_norm};
+pub use misc::{dot_product, squared_diff_norm};
 pub use parallel::{
     BatchedReduction, BinnedDatum, Executor, NestedReduction, ReductionCommon, StandardTeamParam,
     TeamMemberProp, TeamProps, ThreadMember, fill_single_team_statepack_batched,

--- a/crates/pairwise_nostd_internal/src/lib.rs
+++ b/crates/pairwise_nostd_internal/src/lib.rs
@@ -12,6 +12,7 @@ mod state;
 pub mod reduce_sample;
 
 pub use apply_points::{PointProps, apply_accum};
+pub use bins::*;
 pub use misc::{dot_product, get_bin_idx, squared_diff_norm};
 pub use parallel::{
     BatchedReduction, BinnedDatum, Executor, NestedReduction, ReductionCommon, StandardTeamParam,
@@ -19,5 +20,5 @@ pub use parallel::{
     fill_single_team_statepack_nested,
 };
 pub use reduce_utils::reset_full_statepack;
-pub use reducer::{Datum, Mean, OutputDescr, Reducer};
+pub use reducer::{Datum, Histogram, Mean, OutputDescr, Reducer};
 pub use state::{AccumStateView, AccumStateViewMut, StatePackViewMut};

--- a/crates/pairwise_nostd_internal/src/misc.rs
+++ b/crates/pairwise_nostd_internal/src/misc.rs
@@ -1,29 +1,5 @@
 use ndarray::ArrayView2;
 
-// TODO use binary search, and have specialized version for regularly spaced bins?
-/// Get the index of the bin that the squared distance falls into.
-/// Returns None if its out of bounds.
-///
-/// # Note
-/// This is only public so that it can be used in other files. It's not
-/// intended to be used outside ofpublic
-pub fn get_bin_idx(distance_squared: f64, squared_bin_edges: &[f64]) -> Option<usize> {
-    // index of first element greater than distance_squared
-    // (or squared_bin_edges.len() if none are greater)
-    let mut first_greater = 0;
-    for &edge in squared_bin_edges.iter() {
-        if distance_squared < edge {
-            break;
-        }
-        first_greater += 1;
-    }
-    if (first_greater == squared_bin_edges.len()) || (first_greater == 0) {
-        None
-    } else {
-        Some(first_greater - 1)
-    }
-}
-
 /// calculate the squared norm of the difference between two (mathematical) vectors
 /// which are part of rust vecs that encodes a list of vectors with dimension on
 /// the "slow axis"

--- a/crates/pairwise_nostd_internal/src/parallel.rs
+++ b/crates/pairwise_nostd_internal/src/parallel.rs
@@ -103,7 +103,7 @@ impl BinnedDatum {
 ///   testing purposes. (basically it goes through and does the work of 1
 ///   member at a time)
 /// - a team where each member corresponds to a SIMD vector lane (invoked by a
-///  single thread at a time)
+///   single thread at a time)
 ///
 /// The methods are all designed to be entered by all members of a team the
 /// same time. Calls to these methods should be written *as if* there is a

--- a/crates/pairwise_nostd_internal/src/reducer.rs
+++ b/crates/pairwise_nostd_internal/src/reducer.rs
@@ -51,7 +51,7 @@
 //! We will revisit this in the future once we are done architecting other
 //! parts of the design.
 
-use crate::bins::{self, IrregularBins};
+use crate::bins;
 use crate::state::{AccumStateView, AccumStateViewMut};
 use ndarray::ArrayViewMut1;
 
@@ -251,7 +251,7 @@ pub struct Histogram<BinsType: bins::Bins> {
 
 // I think it's good form to have this constructor but I'm not sure that we
 // really need it?
-impl<'a, B: bins::Bins> Histogram<B> {
+impl<B: bins::Bins> Histogram<B> {
     pub fn from_bins(bins: B) -> Histogram<B> {
         Histogram { bins }
     }

--- a/crates/pairwise_nostd_internal/src/reducer.rs
+++ b/crates/pairwise_nostd_internal/src/reducer.rs
@@ -243,8 +243,6 @@ impl Reducer for Mean {
     }
 }
 
-// TODO: refactor so that Histogram doesn't hold a vector and move to
-//       pairwise_internal/accumulator.rs (to )
 pub struct Histogram<BinsType: bins::BinEdges> {
     bins: BinsType,
 }
@@ -259,7 +257,7 @@ impl<B: bins::BinEdges> Histogram<B> {
 
 impl<B: bins::BinEdges> Reducer for Histogram<B> {
     fn accum_state_size(&self) -> usize {
-        self.bins.len()
+        self.bins.n_bins()
     }
 
     /// initializes the storage tracking the acumulator's state
@@ -277,20 +275,20 @@ impl<B: bins::BinEdges> Reducer for Histogram<B> {
     /// merge the state information tracked by `accum_state` and `other`, and
     /// update `accum_state` accordingly
     fn merge(&self, accum_state: &mut AccumStateViewMut, other: &AccumStateView) {
-        for i in 0..self.bins.len() {
+        for i in 0..self.bins.n_bins() {
             accum_state[i] += other[i];
         }
     }
 
     fn output_descr(&self) -> OutputDescr {
         OutputDescr::SingleVecComp {
-            size: self.bins.len(),
+            size: self.bins.n_bins(),
             name: "weight",
         }
     }
 
     fn value_from_accum_state(&self, value: &mut ArrayViewMut1<f64>, accum_state: &AccumStateView) {
-        for i in 0..self.bins.len() {
+        for i in 0..self.bins.n_bins() {
             value[[i]] = accum_state[i];
         }
     }

--- a/crates/pairwise_nostd_internal/src/reducer.rs
+++ b/crates/pairwise_nostd_internal/src/reducer.rs
@@ -245,19 +245,19 @@ impl Reducer for Mean {
 
 // TODO: refactor so that Histogram doesn't hold a vector and move to
 //       pairwise_internal/accumulator.rs (to )
-pub struct Histogram<BinsType: bins::Bins> {
+pub struct Histogram<BinsType: bins::BinEdges> {
     bins: BinsType,
 }
 
 // I think it's good form to have this constructor but I'm not sure that we
 // really need it?
-impl<B: bins::Bins> Histogram<B> {
-    pub fn from_bins(bins: B) -> Histogram<B> {
+impl<B: bins::BinEdges> Histogram<B> {
+    pub fn from_bin_edges(bins: B) -> Histogram<B> {
         Histogram { bins }
     }
 }
 
-impl<B: bins::Bins> Reducer for Histogram<B> {
+impl<B: bins::BinEdges> Reducer for Histogram<B> {
     fn accum_state_size(&self) -> usize {
         self.bins.len()
     }


### PR DESCRIPTION
Introduces the `Bins` trait, and the `RegularBins` and `IrregularBins` structs that implement it.  `Histogram` is now defined in terms of `Bins`, and `apply_accum` has been modified to use it to handle distance bins as well.

While this is ready for review, it is not ready to merge because of (at least) one problem: I'm currently using `floor()`, which is defined in `std`.  If we want `RegularBins` to be part of `pairwise_nostd_internal`, we need a workaround for this.  One option is linking with `libm`.  I'm unclear on whether this would work on the GPU.